### PR TITLE
hotfix/event-carousel

### DIFF
--- a/components/carousel/CarouselIndicatorBar.tsx
+++ b/components/carousel/CarouselIndicatorBar.tsx
@@ -7,9 +7,9 @@ export default function CarouselIndicatorBar(
   props: IndicatorProps
 ): JSX.Element {
   const selectedIndicatorCSS =
-    'w-10 h-10 m-2 rounded-full hover:bg-fcsc-orange shadow hover:shadow-lg transition ease-in duration-200 bg-fcsc-orange'
+    'w-9 h-9 m-2 rounded-full hover:bg-fcsc-orange shadow hover:shadow-lg transition ease-in duration-200 bg-fcsc-orange'
   const unSelectedIndicatorCSS =
-    'w-10 h-10 m-2 rounded-full hover:bg-fcsc-orange shadow hover:shadow-lg transition ease-in duration-200 bg-fcsc-orange_light'
+    'w-9 h-9 m-2 rounded-full hover:bg-fcsc-orange shadow hover:shadow-lg transition ease-in duration-200 bg-fcsc-orange_light'
 
   function renderIndicator(isSelected: boolean, index: number) {
     return (

--- a/components/carousel/event/Event.tsx
+++ b/components/carousel/event/Event.tsx
@@ -24,7 +24,7 @@ export default function Event(props: EventProps): JSX.Element {
             placeholder="blur"
           />
         </div>
-        <div className="p-10 px-0 md:px-10 w-full md:w-3/4  justify-items-center md:justify-items-start ">
+        <div className="p-10 px-0 md:px-10 w-full justify-items-center md:justify-items-start ">
           <h1 className="font-semibold text-3xl text-center md:text-left px-0">
             {props.title}
           </h1>

--- a/components/contactUs/LaunchButton.tsx
+++ b/components/contactUs/LaunchButton.tsx
@@ -35,13 +35,14 @@ export default function LaunchButton(): JSX.Element {
       >
         <Content show={visibility} toggleFunction={toggleVisibility} />
       </div>
-
-      <div
-        className="bg-fcsc-orange px-10 py-3 mt-8 mb-36 rounded-lg shadow-lg hover:shadow-xl transform hover:scale-105 text-white cursor-pointer transition ease-in duration-200 w-full"
-        onClick={toggleVisibility}
-        data-aos="fade-up"
-      >
-        Contact Us
+      <div className="transform hover:scale-105 shadow-lg hover:shadow-xl transition ease-in duration-200">
+        <div
+          className="bg-fcsc-orange px-10 py-3 mt-8 mb-36 rounded-lg   transform hover:scale-105 text-white cursor-pointer w-full"
+          onClick={toggleVisibility}
+          data-aos="fade-up"
+        >
+          Contact Us
+        </div>
       </div>
     </div>
   )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
           blue: '#1c1364', // genuine fcsc blue aka blue_dark
           blue_light: '#33306f',
           orange: '#f15a24', // genuine fcsc orange aka orange_dark
-          orange_light: '#f86b57',
+          orange_light: '#feb6a8',
         },
       },
       boxShadow: {


### PR DESCRIPTION
Issues addressed:

- reduced event carousel height and
   indicator size

- changed the color code of fcsc
   orange light to match one in figma
   design

![Screenshot_1](https://user-images.githubusercontent.com/73662613/126046196-a51dfec5-3477-427d-ad76-97e8e7b09d4d.png)
